### PR TITLE
Introduce InfoUnipoly infolevel and make tests pass

### DIFF
--- a/tst/unipoly.tst
+++ b/tst/unipoly.tst
@@ -9,6 +9,8 @@
 #
 # First, a single example
 #
+gap> INFO_UUU:=InfoLevel(InfoUnipoly);;
+gap> SetInfoLevel(InfoUnipoly,0);
 gap> G:=SO(3,17^2); S:=GeneratorsOfGroup(G);; exp:=Order(G);
 SO(0,3,289)
 24137280
@@ -83,5 +85,6 @@ gap> unipolytest(17,1);
 true
 gap> unipolytest(17,2);
 true
+gap> SetInfoLevel(InfoUnipoly,INFO_UUU);
 
 # that's all!

--- a/unipoly.g
+++ b/unipoly.g
@@ -1,3 +1,6 @@
+InfoUnipoly := NewInfoClass("InfoUnipoly");
+SetInfoLevel(InfoUnipoly,1);
+
 invo:=function(G,Eo)
 # returns an involution produced from a random element in the group G.
 # We assume that the distribution of the elements of even order in the group G
@@ -596,7 +599,7 @@ finished1:=false;
   od;
 k1:=i1*j1;
 ####################
-Print("Basis triangle for the projective plane is constructed.\n");
+Info(InfoUnipoly,1,"Basis triangle for the projective plane is constructed.");
 ####################
 sc:=permij(s,i1,j1,Eo);;
 ti1:=eltor4(ti1,id,Eo);
@@ -610,7 +613,7 @@ mid:=inter(s,i1,di1,j1,dj1,Eo);
     mid:=mid[2];
   fi;
 ####################  
-Print("Black box field K is constructed.\n");
+Info(InfoUnipoly,1,"Black box field K is constructed.");
 ####################
 a2:=add(s,mid,i1,j1,k1,di1,di1,Eo);
   if a2[1]=true then
@@ -649,17 +652,17 @@ finished:=false;
         return tt3;
       fi;
     ####################
-    Print("Analysing an element of the form -x^2-y^2 for random x & y in K^*.\n");
+    Info(InfoUnipoly,1,"Analysing an element of the form -x^2-y^2 for random x & y in K^*.");
     ####################
     ss:=multo(s,mid,i1,j1,k1,di1,tt3[2],l,Eo);
       if ss[1]=true then
         ####################
-        Print("Odd power of -x^2-y^2 is already a unipotent element.\n");
+        Info(InfoUnipoly,1,"Odd power of -x^2-y^2 is already a unipotent element.");
         ####################
         return ss;
       elif ss[2]=di1 then
         ####################
-        Print("-x^2-y^2 is of odd order. On the way to compute a unipotent element.\n");
+        Info(InfoUnipoly,1,"-x^2-y^2 is of odd order. On the way to compute a unipotent element.");
         ####################
         finished:=true;
         sqrttt3:=multo(s,mid,i1,j1,k1,di1,tt3[2],nn,Eo);
@@ -682,7 +685,7 @@ finished:=false;
           fi;
       elif mult(s,mid,i1,j1,k1,ss[2],ss[2],Eo)[2] <> di1 then
         ####################
-        Print("Constructing an element of order 4 from -x^2-y^2 which will be a unipotent element.\n");
+        Info(InfoUnipoly,1,"Constructing an element of order 4 from -x^2-y^2 which will be a unipotent element.");
         ####################
         i:=1;
           while i<=Ee do
@@ -695,7 +698,7 @@ finished:=false;
           od;
         else
           ####################
-          Print("Its order is of the form 2m, m odd. Now, repeating the procedure for different x,y in K.\n");
+          Info(InfoUnipoly,1,"Its order is of the form 2m, m odd. Now, repeating the procedure for different x,y in K.");
           ####################
       fi;
   od;


### PR DESCRIPTION
Now in interactive computation you see this:
```
$ gap unipoly.g
 ┌───────┐   GAP 4.10.0 of 01-Nov-2018
 │  GAP  │   https://www.gap-system.org
 └───────┘   Architecture: x86_64-apple-darwin16.7.0-default64
 Configuration:  gmp 6.1.2, readline
 Loading the library and packages ...
 Packages:   AClib 1.3.1, Alnuth 3.1.0, AtlasRep 1.5.1, AutoDoc 2018.09.20, 
             AutPGrp 1.10, Browse 1.8.8, CRISP 1.4.4, Cryst 4.1.18, CrystCat 1.1.8, 
             CTblLib 1.2.2, FactInt 1.6.2, FGA 1.4.0, GAPDoc 1.6.2, IO 4.5.4, 
             IRREDSOL 1.4, LAGUNA 3.9.0, Polenta 1.3.8, Polycyclic 2.14, PrimGrp 3.3.2, 
             RadiRoot 2.8, ResClasses 4.7.1, SmallGrp 1.3, Sophus 1.24, SpinSym 1.5, 
             TomLib 1.2.7, TransGrp 2.0.4, utils 0.59
 Try '??help' for help. See also '?copyright', '?cite' and '?authors'
gap> G:=SO(3,17^2); S:=GeneratorsOfGroup(G);; exp:=Order(G);
SO(0,3,289)
24137280
gap> u:=unipoly(S,exp);;
#I  Basis triangle for the projective plane is constructed.
#I  Black box field K is constructed.
#I  Analysing an element of the form -x^2-y^2 for random x & y in K^*.
#I  Odd power of -x^2-y^2 is already a unipotent element.
gap> 
```
while tests are run with `InfoUnipoly` equal to zero:
```
$gap tst/testall.g 
 ┌───────┐   GAP 4.10.0 of 01-Nov-2018
 │  GAP  │   https://www.gap-system.org
 └───────┘   Architecture: x86_64-apple-darwin16.7.0-default64
 Configuration:  gmp 6.1.2, readline
 Loading the library and packages ...
 Packages:   AClib 1.3.1, Alnuth 3.1.0, AtlasRep 1.5.1, AutoDoc 2018.09.20, 
             AutPGrp 1.10, Browse 1.8.8, CRISP 1.4.4, Cryst 4.1.18, CrystCat 1.1.8, 
             CTblLib 1.2.2, FactInt 1.6.2, FGA 1.4.0, GAPDoc 1.6.2, IO 4.5.4, 
             IRREDSOL 1.4, LAGUNA 3.9.0, Polenta 1.3.8, Polycyclic 2.14, PrimGrp 3.3.2, 
             RadiRoot 2.8, ResClasses 4.7.1, SmallGrp 1.3, Sophus 1.24, SpinSym 1.5, 
             TomLib 1.2.7, TransGrp 2.0.4, utils 0.59
 Try '??help' for help. See also '?copyright', '?cite' and '?authors'
Architecture: x86_64-apple-darwin16.7.0-default64

testing: tst/unipoly.tst
   51216 ms (1298 ms GC) and 3.55GB allocated for unipoly.tst
-----------------------------------
total     51216 ms (1298 ms GC) and 3.55GB allocated
              0 failures in 1 files

#I  No errors detected while testing
```